### PR TITLE
Gather fits

### DIFF
--- a/erna/__init__.py
+++ b/erna/__init__.py
@@ -91,7 +91,7 @@ def collect_output(job_outputs, output_path, df_started_runs=None, **kwargs):
 
 
 
-def load(earliest_night, latest_night, path_to_data, factdb,source_name="Crab", timedelta_in_minutes="30", data_conditions=dcc.conditions["std"]):
+def load(earliest_night, latest_night, path_to_data, factdb,source_name="Crab", timedelta_in_minutes="30", data_conditions=dcc.conditions["standard"]):
     '''
     Given the earliest and latest night to fetch as a factnight string (as in 20141024) this method returns a DataFrame
     containing the paths to data files and their correpsonding .drs files. The maximum time difference between the

--- a/erna/__init__.py
+++ b/erna/__init__.py
@@ -4,36 +4,36 @@ import os
 import numpy as np
 import datetime
 import json
+import pkg_resources
 from datetime import timedelta
+
 from . import datacheck_conditions as dcc
-from . import qsub
+from .datacheck import get_runs, get_drs_runs
 
 logger = logging.getLogger(__name__)
 
 
-def _build_path(fNight, path_to_data):
-        year = fNight[0:4]
-        month = fNight[4:6]
-        day = fNight[6:8]
-        return os.path.join(path_to_data, year, month, day)
+def build_path(row, path_to_data, extension):
+    night = str(row.NIGHT)
+    year = night[0:4]
+    month = night[4:6]
+    day = night[6:8]
+    return os.path.join(path_to_data, year, month, day, row.filename + extension)
 
-def _build_RunID(fRunID):
-    if(len(fRunID) == 1):
-        return('00' + fRunID)
 
-    if(len(fRunID) == 2):
-        return('0' + fRunID)
-
-    return(fRunID)
+def build_filename(night, run_id):
+    return night.astype(str) + '_' + run_id.map('{:03d}'.format)
 
 
 def mc_drs_file():
     '''
     return path to the drs file used for monte carlo files
     '''
-    import pkg_resources
-    drs_path = pkg_resources.resource_filename(__name__,'resources/mc_drs_constants.drs.fits.gz')
+    drs_path = pkg_resources.resource_filename(
+        __name__, 'resources/mc_drs_constants.drs.fits.gz'
+    )
     return drs_path
+
 
 def ensure_output(output_path):
     '''
@@ -49,8 +49,8 @@ def ensure_output(output_path):
 
 def collect_output(job_outputs, output_path, df_started_runs=None, **kwargs):
     '''
-    Collects the output from the list of job_outputs and merges them into a dataframe. The Dataframe will then be written
-    to a file as specified by the output_path.
+    Collects the output from the list of job_outputs and merges them into a dataframe.
+    The Dataframe will then be written to a file as specified by the output_path.
     The datatframe df_started_runs is joined with the job outputs to get the real ontime.
     '''
     logger.info("Concatenating results from each job and writing result to {}".format(output_path))
@@ -90,101 +90,93 @@ def collect_output(job_outputs, output_path, df_started_runs=None, **kwargs):
         df_returned_data.to_csv(output_path, **kwargs)
 
 
-
-def load(earliest_night, latest_night, path_to_data, factdb,source_name="Crab", timedelta_in_minutes="30", data_conditions=dcc.conditions["standard"]):
+def load(
+        earliest_night,
+        latest_night,
+        path_to_data,
+        factdb,
+        source_name="Crab",
+        timedelta_in_minutes=30,
+        data_conditions=dcc.conditions["standard"]
+        ):
     '''
-    Given the earliest and latest night to fetch as a factnight string (as in 20141024) this method returns a DataFrame
-    containing the paths to data files and their correpsonding .drs files. The maximum time difference between the
-    data and drs files is specified by the timedelta_in_minutes parameter.
+    Given the earliest and latest night to fetch as a factnight string (as in 20141024)
+    this method returns a DataFrame containing the paths to data files
+    and their correpsonding .drs files.
+    The maximum time difference between the data and drs files is
+    specified by the timedelta_in_minutes parameter.
 
     Returns None if no files can be found.
     '''
 
-
-
     logger.debug("Table names in DB: ")
     logger.debug(factdb.table_names())
 
-    if (len(factdb.table_names()) > 0):
+    if len(factdb.table_names()) > 0:
         logger.info("Connected to Database.")
 
+    logger.info("Reading Data from DataBase from {} to {} for source: {}".format(
+        earliest_night, latest_night, source_name
+    ))
 
-    #read source table
-    sourceDB = pd.read_sql_table('Source', factdb, columns=["fSourceName", "fSourceKEY"])
-
-    firstNight = earliest_night
-    lastNight = latest_night
-
-    logger.info("Reading Data from DataBase from " + str(firstNight) + " to " + str(lastNight) +
-                " for source: " + source_name)
-
-    rundb = pd.read_sql("SELECT * from RunInfo WHERE (fNight > " + firstNight + " AND fNight <" + lastNight + ") ", factdb)
-
-
-    #lets try to get all data runs from a specific source between two dates
-    source = sourceDB[sourceDB.fSourceName == source_name]
-    if source.size != 2:
-        # embed()
-        logger.error('Given source name does not return a specific source from the DB')
-        logger.error('Allowed names are: {}'.format(sourceDB.fSourceName) )
-        return pd.DataFrame()
-
-    #source key to conditions for data quality
-    data_conditions += [
-         "fSourceKEY == " + str(int(source.fSourceKEY)),
+    conditions = [
+        'fNight >= {}'.format(earliest_night),
+        'fNight <= {}'.format(latest_night),
+        'fSourceName = "{}"'.format(source_name),
     ]
-    querystring = " & ".join(data_conditions)
-
-    logger.info('Querying data with conditions: {}'.format(querystring))
-    #get all data runs according to the conditions
-    data = rundb.query(querystring)
-
-
+    conditions.extend(data_conditions)
+    logger.info('Querying data with conditions: {}'.format(' AND '.join(conditions)))
+    data = get_runs(
+        factdb,
+        conditions=conditions,
+        columns=(
+            'fNight AS NIGHT', 'fRunID AS RUNID',
+            'fRunStart', 'fRunStop',
+            'fOnTime', 'fEffectiveOn',
+        ),
+    )
 
     # now lets get all drs runs
-    conditions = [
-        "fRunTypeKey == 2", #  300 roi Drs files
-        "fROI == 300",
-        "fDrsStep == 2",
-        # "fZenithDistanceMean < 30",
-        # "fSourceKEY == " + str(int(source.fSourceKEY)),
+    drs_conditions = [
+        'fNight >= {}'.format(earliest_night),
+        'fNight <= {}'.format(latest_night),
     ]
 
-    querystring = " & ".join(conditions)
-    drs_data = rundb.query(querystring)
+    drs_data = get_drs_runs(
+        factdb, conditions=drs_conditions,
+        columns=('fNight AS NIGHT', 'fRunID AS RUNID', 'fRunStart', 'fRunStop'),
+    )
 
     if len(data) == 0 or len(drs_data) == 0:
         logger.error('No data or drs files found that adhere to the specified query.')
         return None
 
-    logger.info("Got " + str(len(data)) + " data entries and " + str(len(drs_data)) + " drs entries")
+    logger.info("Got {} data runs and {} runs".format(len(data), len(drs_data)))
 
-    #the timestamp should be unique for each observation. No two observations start at the same time
-    data = data.set_index("fRunStart")
-    drs_data = drs_data.set_index("fRunStart")
-
-
-
-    #write filenames
-    data["filename"] = data.fNight.astype(str) + "_" + data.fRunID.astype(str).apply(_build_RunID)
-    drs_data["filename"] = drs_data.fNight.astype(str) + "_" + drs_data.fRunID.astype(str).apply(_build_RunID)
-
-    #write path TODO: file ending? is everythiong in fz?
-    data["path"] = data.fNight.astype(str).apply(_build_path, args=[path_to_data]) + "/" + data.filename.astype(str) + ".fits.fz"
-    drs_data["path"] = drs_data.fNight.astype(str).apply(_build_path, args=[path_to_data]) + "/" + drs_data.filename.astype(str) + ".drs.fits.gz"
-
-
-    #sorting data by their timestamp.
+    # the timestamp should be unique for each observation.
+    # No two observations start at the same time
+    data.set_index("fRunStart", inplace=True)
+    drs_data.set_index("fRunStart", inplace=True)
+    # sorting data by their timestamp.
     data = data.sort_index()
     drs_data = drs_data.sort_index()
 
-    #reindex the drs table using the index of the data table. There are always more data runs than drs run in the db.
-    #hence missing rows have to be filled either forward or backwards
+    # write filenames
+    data["filename"] = build_filename(data.NIGHT, data.RUNID)
+    drs_data["filename"] = build_filename(drs_data.NIGHT, drs_data.RUNID)
+
+    # write path TODO: file ending? is everything in fz?
+    data["path"] = data.apply(build_path, axis=1, path_to_data=path_to_data, extension='.fits.fz')
+    drs_data["path"] = drs_data.apply(build_path, axis=1, path_to_data=path_to_data, extension='.drs.fits.gz')
+
+    # reindex the drs table using the index of the data table.
+    # There are always more data runs than drs run in the db.
+    # hence missing rows have to be filled either forward or backwards
     earlier_drs_entries = drs_data.reindex(data.index, method="ffill")
     later_drs_entries = drs_data.reindex(data.index, method="backfill")
 
-
-    #when backfilling the drs obeservations the last rows might be invalid and contain nans. We cannot drop them becasue the tables have to have the same length.
+    # when backfilling the drs obeservations the last rows might be invalid and contain nans.
+    # We cannot drop them becasue the tables have to have the same length.
     # in that case simply fill them up.
     earlier_drs_entries["deltaT"] = np.abs(earlier_drs_entries.fRunStop - data.fRunStop)
     later_drs_entries["deltaT"] = np.abs(later_drs_entries.fRunStop - data.fRunStop).fillna(axis='index', method='ffill')
@@ -194,19 +186,33 @@ def load(earliest_night, latest_night, path_to_data, factdb,source_name="Crab", 
     closest_drs_entries = pd.concat([d_early, d_later])
     closest_drs_entries = closest_drs_entries[closest_drs_entries.deltaT < timedelta(minutes = timedelta_in_minutes)]
 
+    mapping = pd.concat([
+        closest_drs_entries.filename,
+        closest_drs_entries.path,
+        data.path,
+        closest_drs_entries.deltaT,
+        data.fOnTime, data.fEffectiveOn,
+        data.NIGHT,
+        data.RUNID
+    ], axis=1, keys=[
+        "filename",
+        "drs_path",
+        "data_path",
+        "delta_t",
+        "on_time",
+        "effective_on",
+        "NIGHT",
+        "RUNID",
+    ])
 
-    mapping = pd.concat([closest_drs_entries.filename, closest_drs_entries.path, data.path, closest_drs_entries.deltaT, data.fOnTime, data.fEffectiveOn, data.fNight, data.fRunID],
-                                        axis=1, keys=["filename", "drs_path", "data_path", "delta_t", "on_time", "effective_on", "fNight", "fRunID"])
-
-    mapping = mapping.dropna( how='any')
-
-    mapping = mapping.rename(columns={'fNight':'NIGHT', 'fRunID':'RUNID'})
+    mapping = mapping.dropna(how='any')
 
     logger.info("Fetched {} data runs and approx {} drs entries from database where time delta is less than {} minutes".format(len(mapping), mapping['drs_path'].nunique(), timedelta_in_minutes))
     # effective_on_time = (mapping['on_time'] * mapping['effective_on']).sum()
     # logger.info("Effective on time: {}. Thats {} hours.".format(datetime.timedelta(seconds=effective_on_time), effective_on_time/3600))
 
     return mapping
+
 
 def ft_json_to_df(json_path):
     with open(json_path,'r') as text:

--- a/erna/automatic_processing/__main__.py
+++ b/erna/automatic_processing/__main__.py
@@ -63,9 +63,11 @@ def main(config, verbose):
             time.sleep(10)
 
     except (KeyboardInterrupt, SystemExit):
+        log.info('Shutting done')
         job_monitor.terminate()
         job_submitter.terminate()
         job_submitter.join()
+        log.info('Clean up running jobs')
         database.connect()
 
         queued = ProcessingState.get(description='queued')

--- a/erna/automatic_processing/custom_fields.py
+++ b/erna/automatic_processing/custom_fields.py
@@ -1,24 +1,18 @@
-from peewee import Field, BlobField, TextField
+from peewee import Field, BlobField
 import logging
-from datetime import date
+from ..utils import date_to_night_int, night_int_to_date
 
 
 log = logging.getLogger(__name__)
-
-
-def night_int_to_date(night):
-    return date(night // 10000, (night % 10000) // 100, night % 100)
 
 
 class NightField(Field):
     db_field = 'night'
 
     def db_value(self, value):
-        log.debug('Converting date to night integer')
-        return 10000 * value.year + 100 * value.month + value.day
+        return date_to_night_int(value)
 
     def python_value(self, value):
-        log.debug('Converting night integer to date ')
         return night_int_to_date(value)
 
 

--- a/erna/automatic_processing/qsub.py
+++ b/erna/automatic_processing/qsub.py
@@ -147,6 +147,7 @@ def build_automatic_processing_qsub_command(
             'facttools_output_basename': output_basename,
             'ERNA_GROUP': group,
         },
+        queue=queue,
         **kwargs,
     )
 

--- a/erna/datacheck.py
+++ b/erna/datacheck.py
@@ -17,7 +17,7 @@ FROM RunInfo
 JOIN Source
 ON RunInfo.fSourceKey = Source.fSourceKey
 JOIN RunType
-ON RunType.fRunTypeKey = RunType.fRunTypeKey
+ON RunInfo.fRunTypeKey = RunType.fRunTypeKey
 WHERE {conditions}
 ;
 '''

--- a/erna/datacheck.py
+++ b/erna/datacheck.py
@@ -1,0 +1,38 @@
+from .utils import load_config
+import pandas as pd
+
+
+default_columns = (
+    'fNight AS night',
+    'fRunID AS run_id',
+    'fOnTime AS ontime',
+    'fSourceName AS source',
+    'fRunTypeName AS runtype',
+)
+
+
+query_template = '''
+SELECT {columns}
+FROM RunInfo
+JOIN Source
+ON RunInfo.fSourceKey = Source.fSourceKey
+JOIN RunType
+ON RunType.fRunTypeKey = RunType.fRunTypeKey
+WHERE {conditions}
+;
+'''
+
+
+def get_runs(engine, conditions=None, columns=default_columns):
+
+    if conditions is None:
+        conditions = '1'
+    else:
+        conditions = ' AND '.join(conditions)
+
+    query = query_template.format(
+        columns=','.join(columns),
+        conditions=conditions
+    )
+
+    return pd.read_sql_query(query, engine).set_index(['night', 'run_id'])

--- a/erna/datacheck.py
+++ b/erna/datacheck.py
@@ -5,9 +5,9 @@ import pandas as pd
 default_columns = (
     'fNight AS night',
     'fRunID AS run_id',
-    'fOnTime AS ontime',
     'fSourceName AS source',
-    'fRunTypeName AS runtype',
+    'fOnTime AS ontime',
+    'fZenithDistanceMean AS zenith',
 )
 
 

--- a/erna/datacheck.py
+++ b/erna/datacheck.py
@@ -11,7 +11,7 @@ default_columns = (
 )
 
 
-query_template = '''
+query_template_data = '''
 SELECT {columns}
 FROM RunInfo
 JOIN Source
@@ -19,6 +19,17 @@ ON RunInfo.fSourceKey = Source.fSourceKey
 JOIN RunType
 ON RunType.fRunTypeKey = RunType.fRunTypeKey
 WHERE {conditions}
+;
+'''
+
+query_template_drs = '''
+SELECT {columns}
+FROM RunInfo
+WHERE
+    fDrsStep = 2
+    AND fRoi = 300
+    AND fRunTypeKey = 2
+    AND {conditions}
 ;
 '''
 
@@ -30,9 +41,23 @@ def get_runs(engine, conditions=None, columns=default_columns):
     else:
         conditions = ' AND '.join(conditions)
 
-    query = query_template.format(
+    query = query_template_data.format(
         columns=','.join(columns),
         conditions=conditions
     )
 
-    return pd.read_sql_query(query, engine).set_index(['night', 'run_id'])
+    return pd.read_sql_query(query, engine)
+
+
+def get_drs_runs(engine, conditions, columns=('fNight', 'fRunID')):
+    if conditions is None:
+        conditions = '1'
+    else:
+        conditions = ' AND '.join(conditions)
+
+    query = query_template_drs.format(
+        columns=','.join(columns),
+        conditions=conditions
+    )
+
+    return pd.read_sql_query(query, engine)

--- a/erna/datacheck_conditions.py
+++ b/erna/datacheck_conditions.py
@@ -1,106 +1,14 @@
 conditions = dict()
 
-conditions[''] = []
-
-# ------------------------------------------------------------------------------
-conditions['data'] = [
-    'fRunTypeKey == 1',  # Data Events
-    'fROI == 300',
-]
-# ------------------------------------------------------------------------------
-
-conditions['std'] = [
-    'fRunTypeKey == 1',  # Data Events
-    'fMoonZenithDistance > 100',
-    'fROI == 300',
+conditions['standard'] = [
+    'fRunTypeName = "data"',
     'fZenithDistanceMean < 30',
     'fTriggerRateMedian > 40',
     'fTriggerRateMedian < 85',
-    'fOnTime > 0.95',
-    'fThresholdMinSet < 350'
+    'fEffectiveOn > 0.95',
 ]
-
-# ------------------------------------------------------------------------------
-
-conditions['onlyOnTime'] = [
-    'fRunTypeKey == 1',  # Data Events
-    'fROI == 300',
-    'fZenithDistanceMean < 30',
-    #'fTriggerRateMedian > 40',
-    #'fTriggerRateMedian < 85',
-    'fOnTime > 0.95',
-    #'fThresholdMinSet < 350'
-]
-
-# ------------------------------------------------------------------------------
-
-# zdparamStr = 'pow(0.753833 * cos(Radians(fZenithDistanceMean)), 7.647435) * exp(-5.753686*pow(Radians(fZenithDistanceMean),2.089609))'
-# thparamStr = 'pow((if(isnull(fThresholdMinSet),fThresholdMedian,fThresholdMinSet)-329.4203),2) * (-0.0000002044803)'
-# paramStr = '(fNumEvtsAfterBgCuts/5-fNumSigEvts)/fOnTimeAfterCuts - {0} - {1}'.format(zdparamStr, thparamStr)
-# conditions['dorner'] = [
-#     'fNight > 20120420',  # the currentfeedback starts 20120420
-#     'not fNight in [20120406, 20120410, 20120503]',  # different bias voltage
-#     'not 20121206 < fNight < 20130110',  # broken bias channel
-#     # '-0.085 < {0} AND {0} < 0.25'.format(paramStr)
-#     # datacheck parameter condition
-#     # (complex parameter which depends on the results
-#     # of the std analysis at the isdc)
-# ]
-
-# ------------------------------------------------------------------------------
-
-conditions['dorner'] = [
-    'fRunTypeKey == 1', # datafiles
-    'fNight > 20120420',  # the currentfeedback starts 20120420
-    'not fNight in [20120406, 20120410, 20120503]',  # different bias voltage
-    'not 20121206 < fNight < 20130110',  # broken bias channel
-    # '-0.085 < {0} AND {0} < 0.25'.format(paramStr)
-    # datacheck parameter condition
-    # (complex parameter which depends on the results
-    # of the std analysis at the isdc)
-]
-
-# ------------------------------------------------------------------------------
 
 conditions['darknight'] = [
-    'fRunTypeKey == 1', # datafiles
-    'fCurrentsMedMeanBeg < 20',  # light condition cut
-    'fThresholdMinSet < 400',  # light condition cut
-    'fThresholdMinSet < (14 * fCurrentsMedMeanBeg + 265)'  # katjas 'blob' cut
-]
-
-# ------------------------------------------------------------------------------
-
-conditions['Crab20142015'] = [
-'fSourceKEY == 5', # Crab
-'fRunTypeKey == 1', # datafiles
-'fZenithDistanceMax < 30', # zenith cut
-'fZenithDistanceMin > 6', # zenith cut
-'20140630 < fNight < 20150630', # used time range for the set
-'fTriggerRateMedian < 85',
-'fTriggerRateMedian > 40',
-'fMoonZenithDistance > 100',
-'fThresholdMinSet < 350',
-'fEffectiveOn > 0.95',
-]
-conditions['Crab20142015'] += conditions['darknight']
-conditions['Crab20142015'] += conditions['dorner']
-
-# ------------------------------------------------------------------------------
-
-conditions['Crab20132014'] = [
-'fSourceKEY == 5', # Crab
-'fRunTypeKey == 1', # datafiles
-'fZenithDistanceMax < 30', # zenith cut
-'fZenithDistanceMin > 6', # zenith cut
-'20130630 < fNight < 20140205', # used time range for the set
-'fTriggerRateMedian < 85',
-'fTriggerRateMedian > 40',
-'fMoonZenithDistance > 100',
-'fThresholdMinSet < 350',
-'fEffectiveOn > 0.95',
-]
-conditions['Crab20132014'] += conditions['darknight']
-conditions['Crab20132014'] += conditions['dorner']
-
-# ------------------------------------------------------------------------------
+    'fCurrentsMedMean < 20',
+    'fMoonZenithDistance > 100',
+] + conditions['standard']

--- a/erna/hdf_utils.py
+++ b/erna/hdf_utils.py
@@ -1,6 +1,7 @@
 import logging
 import h5py
 from astropy.io import fits
+from tqdm import tqdm
 
 log = logging.getLogger(__name__)
 
@@ -68,13 +69,13 @@ def append_to_hdf5(f, array, groupname='data'):
         dataset[n_existing_rows:] = array[key]
 
 
-def write_fits_to_hdf5(outputfile, inputfiles, mode='w', compression='gzip'):
+def write_fits_to_hdf5(outputfile, inputfiles, mode='w', compression='gzip', progress=True):
 
     initialized = False
 
     with h5py.File(outputfile, mode) as hdf_file:
 
-        for inputfile in inputfiles:
+        for inputfile in tqdm(inputfiles, disable=not progress):
             with fits.open(inputfile) as f:
                 if not initialized:
                     initialize_hdf5(

--- a/erna/hdf_utils.py
+++ b/erna/hdf_utils.py
@@ -72,7 +72,7 @@ def append_to_hdf5(f, array, groupname='events'):
 def write_fits_to_hdf5(
         outputfile,
         inputfiles,
-        mode='w',
+        mode='a',
         compression='gzip',
         progress=True,
         groupname='events',

--- a/erna/hdf_utils.py
+++ b/erna/hdf_utils.py
@@ -77,6 +77,9 @@ def write_fits_to_hdf5(outputfile, inputfiles, mode='w', compression='gzip', pro
 
         for inputfile in tqdm(inputfiles, disable=not progress):
             with fits.open(inputfile) as f:
+                if len(f) < 2:
+                    continue
+
                 if not initialized:
                     initialize_hdf5(
                         hdf_file, f[1].data.dtype, compression=compression

--- a/erna/hdf_utils.py
+++ b/erna/hdf_utils.py
@@ -6,7 +6,7 @@ from tqdm import tqdm
 log = logging.getLogger(__name__)
 
 
-def initialize_hdf5(f, dtypes, groupname='data', **kwargs):
+def initialize_hdf5(f, dtypes, groupname='events', **kwargs):
     '''
     Create a group with name `groupname` and empty datasets for each
     entry in dtypes.
@@ -39,7 +39,7 @@ def initialize_hdf5(f, dtypes, groupname='data', **kwargs):
     return group
 
 
-def append_to_hdf5(f, array, groupname='data'):
+def append_to_hdf5(f, array, groupname='events'):
     '''
     Append a numpy record or structured array to the given hdf5 file
     The file should have been previously initialized with initialize_hdf5
@@ -69,7 +69,14 @@ def append_to_hdf5(f, array, groupname='data'):
         dataset[n_existing_rows:] = array[key]
 
 
-def write_fits_to_hdf5(outputfile, inputfiles, mode='w', compression='gzip', progress=True):
+def write_fits_to_hdf5(
+        outputfile,
+        inputfiles,
+        mode='w',
+        compression='gzip',
+        progress=True,
+        groupname='events',
+        ):
 
     initialized = False
 
@@ -82,8 +89,12 @@ def write_fits_to_hdf5(outputfile, inputfiles, mode='w', compression='gzip', pro
 
                 if not initialized:
                     initialize_hdf5(
-                        hdf_file, f[1].data.dtype, compression=compression
+                        hdf_file,
+                        f[1].data.dtype,
+                        groupname=groupname,
+                        compression=compression,
                     )
                     initialized = True
 
-                append_to_hdf5(hdf_file, f[1].data)
+
+                append_to_hdf5(hdf_file, f[1].data, groupname=groupname)

--- a/erna/scripts/gather_fits.py
+++ b/erna/scripts/gather_fits.py
@@ -84,7 +84,7 @@ def main(xml_name, ft_version, outputfile, config, start, end, source):
 
     cols = ['night', 'run_id', 'source', 'ontime']
     runs_array = successful_jobs[cols].to_records(index=False)
-    initialize_hdf5(outputfile, dtype=runs_array.dtype, groupname='runs')
+    initialize_hdf5(outputfile, dtypes=runs_array.dtype, groupname='runs')
     append_to_hdf5(outputfile, runs_array, groupname='runs')
 
     write_fits_to_hdf5(outputfile, successful_jobs.result_file)

--- a/erna/scripts/gather_fits.py
+++ b/erna/scripts/gather_fits.py
@@ -98,11 +98,10 @@ def main(xml_name, ft_version, outputfile, config, start, end, source, datacheck
     total = len(jobs)
     successful = len(successful_jobs)
     if total != successful:
-        answer = input('Only {} of {} jobs finished, continue? [y, N] :'.format(
-            successful, total
-        ))
-        if not answer.lower().startswith('y'):
-            sys.exit()
+        click.confirm(
+            'Only {} of {} jobs finished, continue? [y, N] :'.format(successful, total),
+            abort=True,
+        )
 
     print('Found {} runs with a total ontime of {:1.2f} h'.format(
         len(jobs), jobs.ontime.sum()/3600

--- a/erna/scripts/gather_fits.py
+++ b/erna/scripts/gather_fits.py
@@ -9,7 +9,7 @@ from ..automatic_processing.database import (
     setup_database, database, Job, RawDataFile, Jar, XML, ProcessingState
 )
 from ..utils import load_config, create_mysql_engine, night_int_to_date
-from ..hdf_utils import write_fits_to_hdf5
+from ..hdf_utils import write_fits_to_hdf5, append_to_hdf5, initialize_hdf5
 from ..datacheck import get_runs
 
 
@@ -81,5 +81,10 @@ def main(xml_name, ft_version, outputfile, config, start, end, source):
     print('Found {} runs with a total ontime of {:1.2f} h'.format(
         len(jobs), jobs.ontime.sum()/3600
     ))
+
+    cols = ['night', 'run_id', 'source', 'ontime']
+    runs_array = successful_jobs[cols].to_records(index=False)
+    initialize_hdf5(outputfile, dtype=runs_array.dtype, groupname='runs')
+    append_to_hdf5(outputfile, runs_array, groupname='runs')
 
     write_fits_to_hdf5(outputfile, successful_jobs.result_file)

--- a/erna/scripts/gather_fits.py
+++ b/erna/scripts/gather_fits.py
@@ -1,0 +1,85 @@
+import pandas as pd
+from astropy.io import fits
+import click
+import h5py
+import dateutil.parser
+import sys
+
+from ..automatic_processing.database import (
+    setup_database, database, Job, RawDataFile, Jar, XML, ProcessingState
+)
+from ..utils import load_config, create_mysql_engine, night_int_to_date
+from ..hdf_utils import write_fits_to_hdf5
+from ..datacheck import get_runs
+
+
+
+@click.command()
+@click.argument('xml-name')
+@click.argument('ft-version')
+@click.argument('outputfile')
+@click.option('--config', '-c')
+@click.option('--start', '-s')
+@click.option('--end', '-e', )
+@click.option('--source', default='Crab')
+def main(xml_name, ft_version, outputfile, config, start, end, source):
+    config = load_config(config)
+    database.init(**config['processing_database'])
+    database.connect()
+
+    processing_db = create_mysql_engine(**config['processing_database'])
+    fact_db = create_mysql_engine(**config['fact_database'])
+
+    jar = (
+        Jar
+        .select(Jar.id, Jar.version)
+        .where(Jar.version == ft_version)
+        .get()
+    )
+
+    xml = XML.get(jar=jar, name=xml_name)
+
+    job_query = (
+        Job
+        .select(
+            RawDataFile.night, RawDataFile.run_id,
+            Job.result_file, ProcessingState.description.alias('status')
+        )
+        .join(RawDataFile)
+        .switch(Job)
+        .join(ProcessingState)
+        .where(Job.jar == jar, Job.xml == xml)
+    )
+    if start:
+        start = dateutil.parser.parse(start).date()
+        job_query = job_query.where(RawDataFile.night >= start)
+    if end:
+        end = dateutil.parser.parse(end).date()
+        job_query = job_query.where(RawDataFile.night <= end)
+
+    sql, params = job_query.sql()
+
+    jobs = pd.read_sql_query(sql, processing_db, params=params)
+    runs = get_runs(fact_db, conditions=[
+        'fRunTypeName = "data"',
+        'fNight <= {}'.format(jobs.night.max()),
+        'fNight >= {}'.format(jobs.night.min()),
+        'fSourceName = "{}"'.format(source),
+    ])
+    jobs = jobs.join(runs, on=['night', 'run_id'], how='inner')
+    successful_jobs = jobs.query('status == "success"')
+
+    total = len(jobs)
+    successful = len(successful_jobs)
+    if total != successful:
+        answer = input('Only {} of {} jobs finished, continue? [y, N] :'.format(
+            successful, total
+        ))
+        if not answer.lower().startswith('y'):
+            sys.exit()
+
+    print('Found {} runs with a total ontime of {:1.2f} h'.format(
+        len(jobs), jobs.ontime.sum()/3600
+    ))
+
+    write_fits_to_hdf5(outputfile, successful_jobs.result_file)

--- a/erna/scripts/gather_fits.py
+++ b/erna/scripts/gather_fits.py
@@ -110,4 +110,6 @@ def main(xml_name, ft_version, outputfile, config, start, end, source, datacheck
         initialize_hdf5(f, dtypes=runs_array.dtype, groupname='runs')
         append_to_hdf5(f, runs_array, groupname='runs')
 
+        f['runs'].attrs['datacheck'] = ' AND '.join(conditions)
+
     write_fits_to_hdf5(outputfile, successful_jobs.result_file, mode='a')

--- a/erna/scripts/gather_fits.py
+++ b/erna/scripts/gather_fits.py
@@ -19,12 +19,27 @@ from ..datacheck_conditions import conditions as datacheck_conditions
 @click.argument('xml-name')
 @click.argument('ft-version')
 @click.argument('outputfile')
-@click.option('--config', '-c')
+@click.option(
+    '--config', '-c', type=click.Path(exists=True, dir_okay=False),
+    help='Path to yaml config file with credentials'
+)
 @click.option('--start', '-s', help='First night to get data from')
 @click.option('--end', '-e', help='Last night to get data from')
 @click.option('--source', default='Crab')
 @click.option('--datacheck', help='The name of a condition set for the datacheck')
 def main(xml_name, ft_version, outputfile, config, start, end, source, datacheck):
+    '''
+    Gather the fits outputfiles of the erna automatic processing into a hdf5 file.
+    The hdf5 file is written using h5py and contains the level 2 features in the
+    `events` group and some metadata for each run in the `runs` group.
+
+    It is possible to only gather files that pass a given datacheck with the --datacheck
+    option. The possible conditions are implemented in erna.datacheck_conditions/
+
+    XML_NAME: name of the xml for which you want to gather output
+    FT_VERSION: FACT Tools version for which you want to gather output
+    OUTPUTFILE: the outputfile
+    '''
     config = load_config(config)
     database.init(**config['processing_database'])
     database.connect()

--- a/erna/scripts/gather_fits.py
+++ b/erna/scripts/gather_fits.py
@@ -50,7 +50,7 @@ def main(xml_name, ft_version, outputfile, config, start, end, source, datacheck
     job_query = (
         Job
         .select(
-            RawDataFile.night, RawDataFile.run_id,
+            RawDataFile.night.alias('night'), RawDataFile.run_id.alias('run_id'),
             Job.result_file, ProcessingState.description.alias('status')
         )
         .join(RawDataFile)

--- a/erna/scripts/gather_fits.py
+++ b/erna/scripts/gather_fits.py
@@ -76,7 +76,7 @@ def main(xml_name, ft_version, outputfile, config, start, end, source, datacheck
     if datacheck is not None:
         conditions.extend(datacheck_conditions[datacheck])
 
-    runs = get_runs(fact_db, conditions=conditions)
+    runs = get_runs(fact_db, conditions=conditions).set_index(('night', 'run_id'))
     jobs = jobs.join(runs, on=['night', 'run_id'], how='inner')
     successful_jobs = jobs.query('status == "success"')
 

--- a/erna/scripts/gather_fits.py
+++ b/erna/scripts/gather_fits.py
@@ -4,6 +4,7 @@ import h5py
 import dateutil.parser
 import sys
 import os
+import numpy as np
 
 from ..automatic_processing.database import (
     database, Job, RawDataFile, Jar, XML, ProcessingState
@@ -81,8 +82,12 @@ def main(xml_name, ft_version, outputfile, config, start, end, source):
         len(jobs), jobs.ontime.sum()/3600
     ))
 
-    cols = ['night', 'run_id', 'source', 'ontime']
-    runs_array = successful_jobs[cols].to_records(index=False)
+    runs_array = np.core.rec.fromarrays([
+        successful_jobs['night'],
+        successful_jobs['run_id'],
+        successful_jobs['source'].astype('S'),
+        successful_jobs['ontime']
+    ], names=('night', 'run_id', 'source', 'ontime'))
 
     if os.path.isfile(outputfile):
         a = input('Outputfile exists! Overwrite? [y, N]: ')

--- a/erna/scripts/gather_fits.py
+++ b/erna/scripts/gather_fits.py
@@ -76,7 +76,7 @@ def main(xml_name, ft_version, outputfile, config, start, end, source, datacheck
     if datacheck is not None:
         conditions.extend(datacheck_conditions[datacheck])
 
-    runs = get_runs(fact_db, conditions=conditions).set_index(('night', 'run_id'))
+    runs = get_runs(fact_db, conditions=conditions).set_index(['night', 'run_id'])
     jobs = jobs.join(runs, on=['night', 'run_id'], how='inner')
     successful_jobs = jobs.query('status == "success"')
 

--- a/erna/utils.py
+++ b/erna/utils.py
@@ -55,8 +55,10 @@ def chown(path, username=None, groupname=None):
 
 
 def night_int_to_date(night):
+    ''' Convert the crazy FACT int to da date instance'''
     return date(night // 10000, (night % 10000) // 100, night % 100)
 
 
 def date_to_night_int(night):
+    ''' convert a date or datetime instance to the crazy FACT int '''
     return 10000 * night.year + 100 * night.month + night.day

--- a/erna/utils.py
+++ b/erna/utils.py
@@ -4,6 +4,7 @@ import logging
 from sqlalchemy import create_engine
 import grp
 import pwd
+from datetime import date
 
 log = logging.getLogger(__name__)
 
@@ -51,3 +52,11 @@ def chown(path, username=None, groupname=None):
     uid = pwd.getpwnam(username).pw_uid if username else -1
     gid = grp.getgrnam(groupname).gr_gid if groupname else -1
     os.chown(path, uid, gid)
+
+
+def night_int_to_date(night):
+    return date(night // 10000, (night % 10000) // 100, night % 100)
+
+
+def date_to_night_int(night):
+    return 10000 * night.year + 100 * night.month + night.day


### PR DESCRIPTION
* Add script to perform datacheck and join corresponding outputfiles into one (h5py) hdf5

The hdf5 contains a group `events` with the features from the fits files, a group `runs` with the columns
night, run_id, ontime, zenith for the selected runs und the query is stored in the metadata:
```
f = h5py.File('my_erna_output.hdf5')
print(f['runs'].attrs['datacheck'])
```

* Refactor erna.load to use the same functions as gather fits (do the datacheck queries on the db, not download the complete db and then do it)

* Refactor datacheck conditions (Removed all but the most basic, as most of the stuff was commented out or contained errors). We might need to add stuff back here.