### PR TITLE
Fix connection already open

### DIFF
--- a/erna/automatic_processing/database.py
+++ b/erna/automatic_processing/database.py
@@ -198,5 +198,5 @@ MODELS = [RawDataFile, DrsFile, Jar, XML, Job, ProcessingState, Queue]
 
 @wrapt.decorator
 def requires_database_connection(wrapped, instance, args, kwargs):
-    database.connect()
+    database.get_conn()
     return wrapped(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='erna',
-    version='0.4.2',
+    version='0.4.3',
     description='Easy RuN Access. Tools that help to do batch processing of FACT data',
     url='https://github.com/fact-project/erna',
     author='Kai Brügge, Jens Buss, Maximilian Nöthe',


### PR DESCRIPTION
After peewee upgrade, the automatic processor was complaining "Connection already open".

Using `get_conn` instead of `connect` fixes this.