### PR TITLE
rename alle occurences of db to aux_source_path

### DIFF
--- a/erna/scripts/process_fact_data.py
+++ b/erna/scripts/process_fact_data.py
@@ -15,14 +15,14 @@ import erna.datacheck_conditions as dcc
 logger = logging.getLogger(__name__)
 
 
-def make_jobs(jar, xml, db_path, output_directory, df_mapping,  engine, queue, vmem, num_runs_per_bunch, walltime):
+def make_jobs(jar, xml, aux_source_path, output_directory, df_mapping,  engine, queue, vmem, num_runs_per_bunch, walltime):
     jobs = []
     # create job objects
     df_mapping["bunch_index"]= np.arange(len(df_mapping)) // num_runs_per_bunch
     for num, df in df_mapping.groupby("bunch_index"):
         df=df.copy()
         df["bunch_index"] = num
-        job = Job(stream_runner.run, [jar, xml, df, db_path], queue=queue, walltime=walltime, engine=engine, mem_free='{}mb'.format(vmem))
+        job = Job(stream_runner.run, [jar, xml, df, aux_source_path], queue=queue, walltime=walltime, engine=engine, mem_free='{}mb'.format(vmem))
         jobs.append(job)
 
     return jobs
@@ -34,7 +34,7 @@ def make_jobs(jar, xml, db_path, output_directory, df_mapping,  engine, queue, v
 @click.argument('data_dir', type=click.Path(exists=True, dir_okay=True, file_okay=False, readable=True) )
 @click.argument('jar', type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True) )
 @click.argument('xml', type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True) )
-@click.argument('db', type=click.Path(exists=True, dir_okay=True, file_okay=True, readable=True) )
+@click.argument('aux_source', type=click.Path(exists=True, dir_okay=True, file_okay=True, readable=True) )
 @click.argument('out', type=click.Path(exists=False, dir_okay=False, file_okay=True, readable=True) )
 @click.option('--queue', help='Name of the queue you want to send jobs to.', default='short')
 @click.option('--walltime', help='Estimated maximum walltime of your job in format hh:mm:ss.', default='02:00:00')
@@ -48,7 +48,7 @@ def make_jobs(jar, xml, db_path, output_directory, df_mapping,  engine, queue, v
 @click.option('--max_delta_t', default=30,  help='Maximum time difference (minutes) allowed between drs and data files.', type=click.INT)
 @click.option('--local', default=False,is_flag=True,   help='Flag indicating whether jobs should be executed localy .')
 @click.password_option(help='password to read from the always awesome RunDB')
-def main(earliest_night, latest_night, data_dir, jar, xml, db, out, queue, walltime, engine, num_runs, vmem, log_level, port, source, conditions, max_delta_t, local, password):
+def main(earliest_night, latest_night, data_dir, jar, xml, aux_source, out, queue, walltime, engine, num_runs, vmem, log_level, port, source, conditions, max_delta_t, local, password):
 
     level=logging.INFO
     if log_level is 'DEBUG':
@@ -65,7 +65,7 @@ def main(earliest_night, latest_night, data_dir, jar, xml, db, out, queue, wallt
     xmlpath =os. path.abspath(xml)
     outpath = os.path.abspath(out)
     erna.ensure_output(out)
-    db_path = os.path.abspath(db)
+    aux_source_path = os.path.abspath(aux_source)
     output_directory = os.path.dirname(outpath)
     # create dir if it doesnt exist
     os.makedirs(output_directory, exist_ok=True)
@@ -84,7 +84,7 @@ def main(earliest_night, latest_night, data_dir, jar, xml, db, out, queue, wallt
     logger.info("Would process {} jobs with {} runs per job".format(len(df_runs)//num_runs, num_runs))
     click.confirm('Do you want to continue processing and start jobs?', abort=True)
 
-    job_list = make_jobs(jarpath, xmlpath, db_path, output_directory, df_runs,  engine, queue, vmem, num_runs, walltime)
+    job_list = make_jobs(jarpath, xmlpath, aux_source_path, output_directory, df_runs,  engine, queue, vmem, num_runs, walltime)
     job_outputs = gridmap.process_jobs(job_list, max_processes=len(job_list), local=local)
     erna.collect_output(job_outputs, out, df_runs)
 

--- a/erna/scripts/process_fact_data_qsub.py
+++ b/erna/scripts/process_fact_data_qsub.py
@@ -54,7 +54,7 @@ def read_outputs_to_list(job_output_paths):
 @click.argument('data_dir', type=click.Path(exists=True, dir_okay=True, file_okay=False, readable=True))
 @click.argument('jar', type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True))
 @click.argument('xml', type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True))
-@click.argument('db', type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True))
+@click.argument('aux_source', type=click.Path(exists=True, dir_okay=True, file_okay=True, readable=True))
 @click.argument('out', type=click.Path(exists=False, dir_okay=False, file_okay=True, readable=True))
 @click.option('--queue', help='Name of the queue you want to send jobs to.', default='short')
 @click.option('--mail', help='qsub mail settings.', default='a')
@@ -70,7 +70,7 @@ def read_outputs_to_list(job_output_paths):
 @click.option('--max_delta_t', default=30,  help='Maximum time difference (minutes) allowed between drs and data files.', type=click.INT)
 @click.option('--local', default=False,is_flag=True,   help='Flag indicating whether jobs should be executed localy .')
 @click.password_option(help='password to read from the always awesome RunDB')
-def main(earliest_night, latest_night, data_dir, jar, xml, db, out, queue, mail,
+def main(earliest_night, latest_night, data_dir, jar, xml, aux_source, out, queue, mail,
          walltime, engine, num_runs, qjobs, vmem, log_level, port, source, conditions,
          max_delta_t, local, password):
 
@@ -91,7 +91,7 @@ def main(earliest_night, latest_night, data_dir, jar, xml, db, out, queue, mail,
     erna.ensure_output(out)
     logger.info("Output data will be written to {}".format(out))
 
-    db_path = os.path.abspath(db)
+    aux_source_path = os.path.abspath(aux_source)
     output_directory = os.path.dirname(outpath)
     # create dir if it doesnt exist
     os.makedirs(output_directory, exist_ok=True)
@@ -128,7 +128,7 @@ def main(earliest_night, latest_night, data_dir, jar, xml, db, out, queue, mail,
         if ( n_toqueue > 0 ) and ( len(df_runs) > 0):
             df_to_submit = df_runs.head(n_toqueue*num_runs).copy()
             processing_identifier = "{}_{}".format(source, time.strftime('%Y%m%d%H%M'))
-            df_submitted_last = q.submit_qsub_jobs(processing_identifier, jarpath, xmlpath, db_path, df_to_submit,  engine, queue, vmem, num_runs, walltime, db, mail)
+            df_submitted_last = q.submit_qsub_jobs(processing_identifier, jarpath, xmlpath, aux_source_path, df_to_submit,  engine, queue, vmem, num_runs, walltime, aux_source, mail)
             df_submitted = df_submitted.append(df_submitted_last)
 
 

--- a/erna/stream_runner.py
+++ b/erna/stream_runner.py
@@ -11,7 +11,7 @@ from erna.utils import (
     )
 
 
-def run(jar, xml, input_files_df, db_path=None):
+def run(jar, xml, input_files_df, aux_source_path=None):
     '''
     This is what will be executed on the cluster
     '''
@@ -23,7 +23,7 @@ def run(jar, xml, input_files_df, db_path=None):
         output_path = os.path.join(output_directory, "output.json")
 
         input_files_df.to_json(input_path, orient='records', date_format='epoch')
-        call = assemble_facttools_call(jar, xml, input_path, output_path, db_path)
+        call = assemble_facttools_call(jar, xml, input_path, output_path, aux_source_path)
 
         check_environment_on_node()
 

--- a/erna/stream_runner_local_output.py
+++ b/erna/stream_runner_local_output.py
@@ -12,7 +12,7 @@ from erna.utils import (
     )
 
 
-def run(jar, xml, input_files_df, output_path, db_path=None):
+def run(jar, xml, input_files_df, output_path, aux_source_path=None):
     '''
     This is a version of ernas stream runner that will be executed on the cluster,
     but writes its results directly to disk without sending them
@@ -26,7 +26,7 @@ def run(jar, xml, input_files_df, output_path, db_path=None):
         tmp_output_path = os.path.join(output_directory, "output.json")
 
         input_files_df.to_json(input_path, orient='records', date_format='epoch')
-        call = assemble_facttools_call(jar, xml, input_path, tmp_output_path, db_path)
+        call = assemble_facttools_call(jar, xml, input_path, tmp_output_path, aux_source_path)
 
         check_environment_on_node()
 

--- a/erna/utils.py
+++ b/erna/utils.py
@@ -65,7 +65,7 @@ def date_to_night_int(night):
     return 10000 * night.year + 100 * night.month + night.day
 
 
-def assemble_facttools_call(jar, xml, input_path, output_path, db_path=None):
+def assemble_facttools_call(jar, xml, input_path, output_path, aux_source_path=None):
     ''' Assemble the call for fact-tools with the given combinations
     of jar, xml, input_path and output_path. The db_path is optional
     for the case where a db_file is needed
@@ -83,7 +83,7 @@ def assemble_facttools_call(jar, xml, input_path, output_path, db_path=None):
             xml,
             '-Dinput=file:{}'.format(input_path),
             '-Doutput=file:{}'.format(output_path),
-            '-Ddb=file:{}'.format(db_path),
+            '-Daux_source=file:{}'.format(aux_source_path),
     ]
     return call
 

--- a/example.xml
+++ b/example.xml
@@ -2,13 +2,13 @@
 
     <properties url="classpath:/default/settings.properties" />
 
-    <property name="db" value="file:/fhgfs/groups/app/fact/drive_2014.sqlite" />
+    <property name="aux_source" value="file:/fhgfs/groups/app/fact/drive_2014.sqlite" />
 
     <property name="integralGainFile" value="classpath:/default/gain_sorted_20131127.csv" />
     <property name="pixelDelayFile" value="classpath:/default/delays_lightpulser_20150217.csv" />
 
 
-    <service id="auxService" class="fact.auxservice.SqliteService" url="${db}" />
+    <service id="auxService" class="fact.auxservice.SqliteService" url="${aux_source}" />
     <service id="calibService" class="fact.calibrationservice.ConstantCalibService" />
 
     <!-- Has to be a  FactFileListMultiStream in order to work on tasks from gridmap and the executor script.-->


### PR DESCRIPTION
this can be done, since the aux service in fact-tool is now also able to handle a directory tree with aux files. The string handed over to fact-tools can be anything and depends on what is used in the XML. Thus we calling this string a aux_source_path makes more sense, since it could e.g. be the path of a sqlite file for the `SQLiteService` or the base directory to the directory tree with a bunch of aux files, as possible for the `AuxService`