### PR TITLE
Fix evaluation of fact-tools version, add command line option to add …

### DIFF
--- a/erna/scripts/upload.py
+++ b/erna/scripts/upload.py
@@ -61,6 +61,9 @@ def xml(config, fact_tools_version, name, comment, xml_file):
         log.error(
             'No database entry for FACT Tools version {}'.format(fact_tools_version)
         )
+        log.error('Available jars are')
+        for jar in Jar.select(Jar.version):
+            log.error(jar.version)
         sys.exit(1)
 
     database.close()

--- a/erna/scripts/upload.py
+++ b/erna/scripts/upload.py
@@ -17,6 +17,9 @@ log.addHandler(logging.StreamHandler())
 
 @click.group()
 def main():
+    '''
+    Upload jar and xml files into the automatic processing database
+    '''
     pass
 
 
@@ -25,8 +28,17 @@ def main():
 @click.option('--fact-tools-version', '-f', help='The FACT-Tools version, the xml is meant for', prompt=True)
 @click.option('--name', '-n', help='The name for the xml', prompt=True)
 @click.option('--comment', '-c', help='A comment to describe the xml')
-@click.argument('xml-file')
+@click.argument('xml-file', type=click.Path(exists=True, dir_okay=False))
 def xml(config, fact_tools_version, name, comment, xml_file):
+    '''
+    Upload a xml into the automatic processing database
+
+    If you do not provide name and fact-tools version on the commandline,
+    you will be promptet for it.
+
+    ARGUMENTS:
+        XML_FILE path to the xml file you want to upload
+    '''
 
     config = load_config(config)
 
@@ -77,6 +89,15 @@ def xml(config, fact_tools_version, name, comment, xml_file):
 @click.option('--version', help='Set the version, if not the jar is executed to obtain it')
 @click.argument('jar-file')
 def jar(config, version, jar_file):
+    '''
+    Upload a FACT-Tools jar into the automatic processing database
+
+    For FACT-Tools versions prior to 0.19.0, you should provide a version
+    string on the commandline using the `--version` option
+
+    ARGUMENTS:
+        JAR_FILE path to the JAR file you want to upload
+    '''
 
     config = load_config(config)
 

--- a/erna/scripts/upload.py
+++ b/erna/scripts/upload.py
@@ -91,7 +91,13 @@ def jar(config, version, jar_file):
             k, value = line.split(':')
             version_info[k.strip()] = value.strip()
 
-        version = version_info['git description']
+        try:
+            version = version_info['git description']
+        except KeyError:
+            click.echo(
+                'Jar did not report version, please use the `--version` option'
+            )
+            raise click.Abort()
         log.info('Found FACT Tools version "{}"'.format(version))
     else:
         log.info('Using version from the command line: "{}"'.format(version))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='erna',
-    version='0.5.1',
+    version='0.5.2',
     description='Easy RuN Access. Tools that help to do batch processing of FACT data',
     url='https://github.com/fact-project/erna',
     author='Kai Brügge, Jens Buss, Maximilian Nöthe',


### PR DESCRIPTION
* Read Version from the jar, only possible for FACT-Tools after https://github.com/fact-project/fact-tools/pull/281

* Add possibility to provide a version string on the command-line 