### PR TITLE
New conditions

### DIFF
--- a/erna/datacheck_conditions.py
+++ b/erna/datacheck_conditions.py
@@ -1,6 +1,6 @@
 conditions = dict()
 
-def create_condition_set(conditions=['standard']):
+def create_condition_set(conditions=['@standard']):
     """
     given a list of conditions create a condition set
     

--- a/erna/datacheck_conditions.py
+++ b/erna/datacheck_conditions.py
@@ -1,20 +1,7 @@
 conditions = dict()
 
-def create_condition_set(conditionset=['@standard']):
-    """
-    given a list of conditions create a condition set
-    
-    If a given condition start with '@NAME', process NAME as a set of conditions defined in the variabel conditions.
-    """
-    data_conditions = ['fRunTypeName = "data"']
-    for condition in conditionset:
-        if condition.startswith('@'):
-            data_conditions = data_conditions+conditionset[condition[1:]]
-        else:
-            data_conditions.append(condition)
-    return data_conditions
-    
 conditions['standard'] = [
+    'fRunTypeName = "data"',
     'fZenithDistanceMean < 30',
     'fTriggerRateMedian > 40',
     'fTriggerRateMedian < 85',
@@ -25,41 +12,3 @@ conditions['darknight'] = [
     'fCurrentsMedMean < 20',
     'fMoonZenithDistance > 100',
 ] + conditions['standard']
-
-
-conditions['low_zenith'] = [
-    'fZenithDistanceMax < 30',
-]
-
-conditions['no_moonlight'] = [
-    'fCurrentsMedMeanBeg < 8',
-    'fMoonZenithDistance > 100',
-    'fThresholdMinSet < 350',
-    'fEffectiveOn > 0.95',
-    'fTriggerRateMedian > 40',
-    'fTriggerRateMedian < 85',
-    'fThresholdMinSet < (14 * fCurrentsMedMeanBeg + 265)'
-]
-
-conditions['low_moonlight'] = [
-    'fTriggerRateMedian < 85',
-    'fZenithDistanceMax < 30',
-    'fThresholdMinSet < (14 * fCurrentsMedMeanBeg + 265)',
-    'fCurrentsMedMeanBeg > 8',
-    'fCurrentsMedMeanBeg <= 16',
-]
-
-
-conditions['moderate_moonlight'] = [
-    'fTriggerRateMedian < 85',
-    'fThresholdMinSet < (14 * fCurrentsMedMeanBeg + 265)',
-    'fCurrentsMedMeanBeg > 32',
-    'fCurrentsMedMeanBeg <= 48',
-]
-
-conditions['strong_moonlight'] = [
-    'fTriggerRateMedian < 85',
-    'fThresholdMinSet < (14 * fCurrentsMedMeanBeg + 265)',
-    'fCurrentsMedMeanBeg > 64',
-    'fCurrentsMedMeanBeg <= 96',
-]

--- a/erna/datacheck_conditions.py
+++ b/erna/datacheck_conditions.py
@@ -12,3 +12,40 @@ conditions['darknight'] = [
     'fCurrentsMedMean < 20',
     'fMoonZenithDistance > 100',
 ] + conditions['standard']
+
+
+conditions['no_moonlight'] = [
+    'fCurrentsMedMeanBeg < 8',
+    'fZenithDistanceMax < 30',
+    'fMoonZenithDistance > 100',
+    'fThresholdMinSet < 350',
+    'fEffectiveOn > 0.95',
+    'fTriggerRateMedian > 40',
+    'fTriggerRateMedian < 85',
+    'fThresholdMinSet < (14 * fCurrentsMedMeanBeg + 265)'
+]
+
+conditions['low_moonlight'] = [
+    'fTriggerRateMedian < 85',
+    'fZenithDistanceMax < 30',
+    'fThresholdMinSet < (14 * fCurrentsMedMeanBeg + 265)',
+    'fCurrentsMedMeanBeg > 8',
+    'fCurrentsMedMeanBeg <= 16',
+]
+
+
+conditions['moderate_moonlight'] = [
+    'fTriggerRateMedian < 85',
+    'fZenithDistanceMax < 30',
+    'fThresholdMinSet < (14 * fCurrentsMedMeanBeg + 265)',
+    'fCurrentsMedMeanBeg > 32',
+    'fCurrentsMedMeanBeg <= 48',
+]
+
+conditions=['strong_moonlight'] = [
+    'fTriggerRateMedian < 85',
+    'fZenithDistanceMax < 30',
+    'fThresholdMinSet < (14 * fCurrentsMedMeanBeg + 265)',
+    'fCurrentsMedMeanBeg > 64',
+    'fCurrentsMedMeanBeg <= 96',
+]

--- a/erna/datacheck_conditions.py
+++ b/erna/datacheck_conditions.py
@@ -15,6 +15,7 @@ conditions['darknight'] = [
 
 
 conditions['no_moonlight'] = [
+    'fRunTypeName = "data"',
     'fCurrentsMedMeanBeg < 8',
     'fZenithDistanceMax < 30',
     'fMoonZenithDistance > 100',
@@ -26,6 +27,7 @@ conditions['no_moonlight'] = [
 ]
 
 conditions['low_moonlight'] = [
+    'fRunTypeName = "data"',
     'fTriggerRateMedian < 85',
     'fZenithDistanceMax < 30',
     'fThresholdMinSet < (14 * fCurrentsMedMeanBeg + 265)',
@@ -35,6 +37,7 @@ conditions['low_moonlight'] = [
 
 
 conditions['moderate_moonlight'] = [
+    'fRunTypeName = "data"',
     'fTriggerRateMedian < 85',
     'fZenithDistanceMax < 30',
     'fThresholdMinSet < (14 * fCurrentsMedMeanBeg + 265)',
@@ -43,6 +46,7 @@ conditions['moderate_moonlight'] = [
 ]
 
 conditions=['strong_moonlight'] = [
+    'fRunTypeName = "data"',
     'fTriggerRateMedian < 85',
     'fZenithDistanceMax < 30',
     'fThresholdMinSet < (14 * fCurrentsMedMeanBeg + 265)',

--- a/erna/datacheck_conditions.py
+++ b/erna/datacheck_conditions.py
@@ -1,7 +1,19 @@
 conditions = dict()
 
+def create_condition_set(conditions=['standard']):
+    """
+    given a list of conditions create a condition set
+    
+    If a given condition start with '@NAME', process NAME as a set of conditions defined in the variabel conditions.
+    """
+    data_conditons = ['fRunTypeName = "data"']
+    if condition.startswith('@'):
+            data_conditions = data_condition+dcc.conditions[condition[1:]]
+        else:
+            data_conditions.append(condition)
+    return data_conditons
+    
 conditions['standard'] = [
-    'fRunTypeName = "data"',
     'fZenithDistanceMean < 30',
     'fTriggerRateMedian > 40',
     'fTriggerRateMedian < 85',
@@ -14,10 +26,12 @@ conditions['darknight'] = [
 ] + conditions['standard']
 
 
-conditions['no_moonlight'] = [
-    'fRunTypeName = "data"',
-    'fCurrentsMedMeanBeg < 8',
+conditions['low_zenith'] = [
     'fZenithDistanceMax < 30',
+]
+
+conditions['no_moonlight'] = [
+    'fCurrentsMedMeanBeg < 8',
     'fMoonZenithDistance > 100',
     'fThresholdMinSet < 350',
     'fEffectiveOn > 0.95',
@@ -27,7 +41,6 @@ conditions['no_moonlight'] = [
 ]
 
 conditions['low_moonlight'] = [
-    'fRunTypeName = "data"',
     'fTriggerRateMedian < 85',
     'fZenithDistanceMax < 30',
     'fThresholdMinSet < (14 * fCurrentsMedMeanBeg + 265)',
@@ -37,18 +50,14 @@ conditions['low_moonlight'] = [
 
 
 conditions['moderate_moonlight'] = [
-    'fRunTypeName = "data"',
     'fTriggerRateMedian < 85',
-    'fZenithDistanceMax < 30',
     'fThresholdMinSet < (14 * fCurrentsMedMeanBeg + 265)',
     'fCurrentsMedMeanBeg > 32',
     'fCurrentsMedMeanBeg <= 48',
 ]
 
-conditions=['strong_moonlight'] = [
-    'fRunTypeName = "data"',
+conditions['strong_moonlight'] = [
     'fTriggerRateMedian < 85',
-    'fZenithDistanceMax < 30',
     'fThresholdMinSet < (14 * fCurrentsMedMeanBeg + 265)',
     'fCurrentsMedMeanBeg > 64',
     'fCurrentsMedMeanBeg <= 96',

--- a/erna/scripts/fetch_fact_runs.py
+++ b/erna/scripts/fetch_fact_runs.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 @click.option('--source',  help='Name of the source to analyze. e.g Crab', default='Crab')
 @click.option('--max_delta_t', default=30,  help='Maximum time difference (minutes) allowed between drs and data files.', type=click.INT)
 @click.option('--parts', default=1, help='Number of parts to split the .json file into. This is useful for submitting this to a cluster later on', type=click.INT)
-@click.option('--conditions',  help='Name of the data conditions as given in datacheck_conditions.py e.g std', default='std')
+@click.option('--conditions', '-c', help='Name of the data conditions as given in datacheck_conditions.py e.g @standard or "fParameter < 42 "', default=['@standard'], multiple=True)
 @click.password_option(help='password to read from the always awesome RunDB')
 def main(earliest_night, latest_night, data_dir, source,  max_delta_t, parts, password, conditions):
     '''  This script connects to the rundb and fetches all runs belonging to the specified source.
@@ -32,7 +32,9 @@ def main(earliest_night, latest_night, data_dir, source,  max_delta_t, parts, pa
 
     factdb = create_engine("mysql+pymysql://factread:{}@129.194.168.95/factdata".format(password))
 
-    data_conditions=dcc.conditions[conditions]
+    # create the set of conditions we want to use
+    data_conditions = dcc.create_condition_set(conditions)
+    
     mapping = erna.load(earliest_night, latest_night, data_dir,  source_name=source, timedelta_in_minutes=max_delta_t, factdb=factdb, data_conditions=data_conditions)
     if mapping.empty:
         logger.error('No entries matching the conditions could be found in the RunDB')

--- a/erna/scripts/fetch_fact_runs.py
+++ b/erna/scripts/fetch_fact_runs.py
@@ -10,6 +10,7 @@ import erna.datacheck_conditions as dcc
 
 logger = logging.getLogger(__name__)
 
+from fact_conditions import create_condition_set
 
 @click.command()
 @click.argument('earliest_night')
@@ -33,7 +34,7 @@ def main(earliest_night, latest_night, data_dir, source,  max_delta_t, parts, pa
     factdb = create_engine("mysql+pymysql://factread:{}@129.194.168.95/factdata".format(password))
 
     # create the set of conditions we want to use
-    data_conditions = dcc.create_condition_set(conditions)
+    data_conditions = create_condition_set(conditions)
     
     mapping = erna.load(earliest_night, latest_night, data_dir,  source_name=source, timedelta_in_minutes=max_delta_t, factdb=factdb, data_conditions=data_conditions)
     if mapping.empty:

--- a/erna/scripts/process_fact_data.py
+++ b/erna/scripts/process_fact_data.py
@@ -44,7 +44,7 @@ def make_jobs(jar, xml, aux_source_path, output_directory, df_mapping,  engine, 
 @click.option('--log_level', type=click.Choice(['INFO', 'DEBUG', 'WARN']), help='increase output verbosity', default='INFO')
 @click.option('--port', help='The port through which to communicate with the JobMonitor', default=12856, type=int)
 @click.option('--source',  help='Name of the source to analyze. e.g Crab', default='Crab')
-@click.option('--conditions',  help='Name of the data conditions as given in datacheck_conditions.py e.g standard', default='standard')
+@click.option('--conditions', '-c', help='Name of the data conditions as given in datacheck_conditions.py e.g standard', default=['standard'], multiple=True)
 @click.option('--max_delta_t', default=30,  help='Maximum time difference (minutes) allowed between drs and data files.', type=click.INT)
 @click.option('--local', default=False,is_flag=True,   help='Flag indicating whether jobs should be executed localy .')
 @click.password_option(help='password to read from the always awesome RunDB')
@@ -71,7 +71,10 @@ def main(earliest_night, latest_night, data_dir, jar, xml, aux_source, out, queu
     os.makedirs(output_directory, exist_ok=True)
     logger.info("Writing output data  to {}".format(out))
     factdb = sqlalchemy.create_engine("mysql+pymysql://factread:{}@129.194.168.95/factdata".format(password))
-    data_conditions=dcc.conditions[conditions]
+
+    # create the set of conditions we want to use
+    data_conditions = dcc.create_condition_set(conditions)
+
     df_runs = erna.load(earliest_night, latest_night, data_dir, source_name=source, timedelta_in_minutes=max_delta_t, factdb=factdb, data_conditions=data_conditions)
     
     # check for missing data and fix possible wrong file extension (.fz->.gz)

--- a/erna/scripts/process_fact_data.py
+++ b/erna/scripts/process_fact_data.py
@@ -27,6 +27,7 @@ def make_jobs(jar, xml, aux_source_path, output_directory, df_mapping,  engine, 
 
     return jobs
 
+from fact_conditions import create_condition_set
 
 @click.command()
 @click.argument('earliest_night')
@@ -73,7 +74,7 @@ def main(earliest_night, latest_night, data_dir, jar, xml, aux_source, out, queu
     factdb = sqlalchemy.create_engine("mysql+pymysql://factread:{}@129.194.168.95/factdata".format(password))
 
     # create the set of conditions we want to use
-    data_conditions = dcc.create_condition_set(conditions)
+    data_conditions = create_condition_set(conditions)
 
     df_runs = erna.load(earliest_night, latest_night, data_dir, source_name=source, timedelta_in_minutes=max_delta_t, factdb=factdb, data_conditions=data_conditions)
     

--- a/erna/scripts/process_fact_data.py
+++ b/erna/scripts/process_fact_data.py
@@ -44,7 +44,7 @@ def make_jobs(jar, xml, aux_source_path, output_directory, df_mapping,  engine, 
 @click.option('--log_level', type=click.Choice(['INFO', 'DEBUG', 'WARN']), help='increase output verbosity', default='INFO')
 @click.option('--port', help='The port through which to communicate with the JobMonitor', default=12856, type=int)
 @click.option('--source',  help='Name of the source to analyze. e.g Crab', default='Crab')
-@click.option('--conditions', '-c', help='Name of the data conditions as given in datacheck_conditions.py e.g standard', default=['standard'], multiple=True)
+@click.option('--conditions', '-c', help='Name of the data conditions as given in datacheck_conditions.py e.g @standard or "fParameter < 42 "', default=['@standard'], multiple=True)
 @click.option('--max_delta_t', default=30,  help='Maximum time difference (minutes) allowed between drs and data files.', type=click.INT)
 @click.option('--local', default=False,is_flag=True,   help='Flag indicating whether jobs should be executed localy .')
 @click.password_option(help='password to read from the always awesome RunDB')

--- a/erna/scripts/process_fact_data_qsub.py
+++ b/erna/scripts/process_fact_data_qsub.py
@@ -46,7 +46,7 @@ def read_outputs_to_list(job_output_paths):
 
 
 
-
+from fact_conditions import create_condition_set
 
 @click.command()
 @click.argument('earliest_night')
@@ -99,7 +99,7 @@ def main(earliest_night, latest_night, data_dir, jar, xml, aux_source, out, queu
     factdb = sqlalchemy.create_engine("mysql+pymysql://factread:{}@129.194.168.95/factdata".format(password))
     
     # create the set of conditions we want to use
-    data_conditions = dcc.create_condition_set(conditions)
+    data_conditions = create_condition_set(conditions)
     
     df_loaded = erna.load(earliest_night, latest_night, data_dir, source_name=source, timedelta_in_minutes=max_delta_t, factdb=factdb, data_conditions=data_conditions)
     df_loaded.to_hdf(out+".tmp", "loaded", mode="a")

--- a/erna/scripts/process_fact_data_qsub.py
+++ b/erna/scripts/process_fact_data_qsub.py
@@ -66,7 +66,7 @@ def read_outputs_to_list(job_output_paths):
 @click.option('--log_level', type=click.Choice(['INFO', 'DEBUG', 'WARN']), help='increase output verbosity', default='INFO')
 @click.option('--port', help='The port through which to communicate with the JobMonitor', default=12856, type=int)
 @click.option('--source',  help='Name of the source to analyze. e.g Crab', default='Crab')
-@click.option('--conditions',  help='Name of the data conditions as given in datacheck_conditions.py e.g std', default='data')
+@click.option('--conditions', '-c', help='Name of the data conditions as given in datacheck_conditions.py e.g @standard or "fParameter < 42 "', default=['@standard'], multiple=True)
 @click.option('--max_delta_t', default=30,  help='Maximum time difference (minutes) allowed between drs and data files.', type=click.INT)
 @click.option('--local', default=False,is_flag=True,   help='Flag indicating whether jobs should be executed localy .')
 @click.password_option(help='password to read from the always awesome RunDB')
@@ -97,7 +97,10 @@ def main(earliest_night, latest_night, data_dir, jar, xml, aux_source, out, queu
     os.makedirs(output_directory, exist_ok=True)
 
     factdb = sqlalchemy.create_engine("mysql+pymysql://factread:{}@129.194.168.95/factdata".format(password))
-    data_conditions=dcc.conditions[conditions]
+    
+    # create the set of conditions we want to use
+    data_conditions = dcc.create_condition_set(conditions)
+    
     df_loaded = erna.load(earliest_night, latest_night, data_dir, source_name=source, timedelta_in_minutes=max_delta_t, factdb=factdb, data_conditions=data_conditions)
     df_loaded.to_hdf(out+".tmp", "loaded", mode="a")
 

--- a/erna/scripts/process_fact_mc.py
+++ b/erna/scripts/process_fact_mc.py
@@ -14,23 +14,9 @@ from tqdm import tqdm
 import glob
 
 logger = logging.getLogger(__name__)
-
-import re
-
-def create_filename_from_format(filename_format, basename, num):
-    """
-    Given a special format string, create a filename_format with the basename and a given number.
-    There are two named variables that can be used, one is basename which inserts the basename
-    and the second one is num which is mandatory.
-    """
-    m = re.search('\{num', filename_format)
-    if not m:
-        raise ValueError("Missing named placeholder 'num' in format string")
-    return filename_format.format({"basename":basename, "num":num})
-
 	
 def make_jobs(jar, xml, data_paths, drs_paths,
-              engine, queue, vmem, num_jobs, walltime, output_path=None, filename_format="{basename}_{num}.json"):
+              engine, queue, vmem, num_jobs, walltime, output_path=None, filename_format="json"):
     jobs = []
 
     data_partitions = np.array_split(data_paths, num_jobs)
@@ -45,7 +31,7 @@ def make_jobs(jar, xml, data_paths, drs_paths,
         if output_path:
             # create the filenames for each single local run
             file_name, _ = path.splitext(path.basename(output_path))
-            file_name = create_filename_from_format(filename_format, file_name, num)
+            file_name = "{}_{}.{}".format(file_name, num, filename_format)
             out_path = path.dirname(output_path)
             run = [jar, xml, df, path.join(out_path, file_name)]
             stream_runner = stream_runner_local
@@ -91,9 +77,7 @@ def make_jobs(jar, xml, data_paths, drs_paths,
               show_default=True)
 @click.option('--mcdrs', type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True))
 @click.option('--mcwildcard', help="Gives the wildcard for searching the folder for files.", type=click.STRING, default='**/*_Events.fit*')
-@click.option('--local_output_format', default="{basename}_{num}.json", help="Give the file format for the local output funktionality."
-              + "%b will replace the out filename and %[1-9]n the given local number."
-              + "Default is: '{basename}_{num}.json'.Only works with option --local_output. ")
+@click.option('--local_output_format', default="json", help="Give the file format for the local output funktionality.")
 def main( jar, xml, out, mc_path, queue, walltime, engine, num_jobs, vmem, log_level, port, local, local_output, mcdrs, mcwildcard, local_output_format):
     '''
     Script to execute fact-tools on MonteCarlo files. Use the MC_PATH argument to specifiy the folders containing the MC

--- a/erna/scripts/process_fact_mc.py
+++ b/erna/scripts/process_fact_mc.py
@@ -16,7 +16,7 @@ import glob
 logger = logging.getLogger(__name__)
 	
 def make_jobs(jar, xml, data_paths, drs_paths,
-              engine, queue, vmem, num_jobs, walltime, output_path=None, filename_format="json"):
+              engine, queue, vmem, num_jobs, walltime, output_path=None, local_output_extension="json"):
     jobs = []
 
     data_partitions = np.array_split(data_paths, num_jobs)
@@ -31,7 +31,7 @@ def make_jobs(jar, xml, data_paths, drs_paths,
         if output_path:
             # create the filenames for each single local run
             file_name, _ = path.splitext(path.basename(output_path))
-            file_name = "{}_{}.{}".format(file_name, num, filename_format)
+            file_name = "{}_{}.{}".format(file_name, num, local_output_extension)
             out_path = path.dirname(output_path)
             run = [jar, xml, df, path.join(out_path, file_name)]
             stream_runner = stream_runner_local
@@ -77,8 +77,8 @@ def make_jobs(jar, xml, data_paths, drs_paths,
               show_default=True)
 @click.option('--mcdrs', type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True))
 @click.option('--mcwildcard', help="Gives the wildcard for searching the folder for files.", type=click.STRING, default='**/*_Events.fit*')
-@click.option('--local_output_format', default="json", help="Give the file format for the local output funktionality.")
-def main( jar, xml, out, mc_path, queue, walltime, engine, num_jobs, vmem, log_level, port, local, local_output, mcdrs, mcwildcard, local_output_format):
+@click.option('--local_output_extension', default="json", help="Give the file format for the local output funktionality.")
+def main( jar, xml, out, mc_path, queue, walltime, engine, num_jobs, vmem, log_level, port, local, local_output, mcdrs, mcwildcard, local_output_extension):
     '''
     Script to execute fact-tools on MonteCarlo files. Use the MC_PATH argument to specifiy the folders containing the MC
     '''
@@ -133,7 +133,7 @@ def main( jar, xml, out, mc_path, queue, walltime, engine, num_jobs, vmem, log_l
         job_list = make_jobs(
                         jarpath, xmlpath, mc_paths_array,
                         drs_paths_array,  engine, queue,
-                        vmem, num_jobs, walltime, output_path=local_output_dir, filename_format=local_output_format
+                        vmem, num_jobs, walltime, output_path=local_output_dir, local_output_extension=local_output_extension
                         )
     else:
         job_list = make_jobs(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 https://github.com/fact-project/fact_conditions/archive/v0.1.tar.gz#egg=fact_conditions
-git+https://github.com/mackaiver/gridmap@a38271b35a96adbda0c0f3e62f3751b3c8c3982a#egg=gridmap
+https://github.com/mackaiver/gridmap@a38271b35a96adbda0c0f3e62f3751b3c8c3982a#egg=gridmap

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/fact-project/fact_conditions#egg=fact_conditions
-git+https://github.com/mackaiver/gridmap#egg=gridmap
+git+https://github.com/fact-project/fact_conditions@v0.1#egg=fact_conditions
+git+https://github.com/mackaiver/gridmap@a38271b35a96adbda0c0f3e62f3751b3c8c3982a#egg=gridmap

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/fact-project/fact_conditions@v0.1#egg=fact_conditions
+https://github.com/fact-project/fact_conditions/archive/v0.1.tar.gz#egg=fact_conditions
 git+https://github.com/mackaiver/gridmap@a38271b35a96adbda0c0f3e62f3751b3c8c3982a#egg=gridmap

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+git+https://github.com/fact-project/fact_conditions#egg=fact_conditions
+git+https://github.com/mackaiver/gridmap#egg=gridmap

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-https://github.com/fact-project/fact_conditions/archive/v0.1.tar.gz#egg=fact_conditions
-https://github.com/mackaiver/gridmap@a38271b35a96adbda0c0f3e62f3751b3c8c3982a#egg=gridmap
+https://github.com/fact-project/fact_conditions/archive/v0.1.tar.gz
+https://github.com/mackaiver/gridmap/archive/a38271b35a96adbda0c0f3e62f3751b3c8c3982a.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='erna',
-    version='0.8.2',
+    version='0.8.3',
     description='Easy RuN Access. Tools that help to do batch processing of FACT data',
     url='https://github.com/fact-project/erna',
     author='Kai Brügge, Jens Buss, Maximilian Nöthe',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'xmltodict',
         'wrapt',
         # 'gridmap>=0.13.1', install from https://github.com/mackaiver/gridmap'
-        'fact_condition',
+        # 'fact_condition', install from https://github.com/fact-project/fact_conditions
     ],
     zip_safe=False,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'xmltodict',
         'wrapt',
         # 'gridmap>=0.13.1', install from https://github.com/mackaiver/gridmap'
+        'fact_condition',
     ],
     zip_safe=False,
     entry_points={


### PR DESCRIPTION
New functionality for erna. This PR enhances the current `process_fact_runs.py` and `fetch_fact_runs.py` to use the new @fact-project/fact_conditions project. This allows for setting nice and easy conditions for the data runs by specifying them in yaml files (see examples in fact_conditions project in the conditions folder) or by setting them directly in the cmd line or both. 

This change should work without any changes to current executions as long as it didn't use the `--conditions` option (which shouldn't have been used anyways as it does not do anything useful really).

Exp.:

`process_fact_data 20130630 20140206 /fact/raw ${FACT_TOOLS} ${XML_FOLDER}/example.xml /fact/aux ${output}/test.hdf5  --walltime=6:00:00 --num_runs 4 --vmem 10000 -c "@/home/projects/fact_tools/crab1314_moderate_moonlight.yaml`

`process_fact_data 20130630 20140206 /fact/raw ${FACT_TOOLS} ${XML_FOLDER}/example.xml /fact/aux ${output}/test.hdf5  --walltime=6:00:00 --num_runs 4 --vmem 10000 -c "@/home/projects/fact_tools/crab1314_moderate_moonlight.yaml" -c "fCurrentsMedMeanBeg > 64"`