### PR TITLE
Allow to reprocess failed runs

### DIFF
--- a/erna/__init__.py
+++ b/erna/__init__.py
@@ -124,8 +124,9 @@ def collect_output(job_outputs, output_path, df_started_runs=None, **kwargs):
         if len(df_failed) > 0:
             name, extension = os.path.splitext(output_path)
             failed_file_list_path = name+"_failed_runs.csv"
+
             logger.info("Writing list of failed runs to: {}".format(failed_file_list_path))
-            df_failed.to_csv(failed_file_list_path, **kwargs)
+            df_failed.to_csv(failed_file_list_path, columns=df_started_runs.columns, **kwargs)
             
 
     df_returned_data.columns = rename_columns(df_returned_data.columns)

--- a/erna/__init__.py
+++ b/erna/__init__.py
@@ -124,7 +124,7 @@ def collect_output(job_outputs, output_path, df_started_runs=None, **kwargs):
         df_successfull = df_merged.query("failed == False")
         df_failed = df_merged.query("failed == True")
 
-        if (set(['ontime']).issubset(df_successfull.columns)):
+        if 'ontime' in df_successfull.columns:
             total_on_time_in_seconds = df_successfull.ontime.sum()
             logger.info("Effective on time: {}. Thats {} hours.".format(datetime.timedelta(seconds=total_on_time_in_seconds), total_on_time_in_seconds/3600))
 

--- a/erna/scripts/process_fact_mc.py
+++ b/erna/scripts/process_fact_mc.py
@@ -27,11 +27,14 @@ def make_jobs(jar, xml, data_paths, drs_paths,
     else:
         logger.debug("Using std stream runner gathering output from all nodes")
 
+    df_runs = pd.DataFrame()
     for num, (data, drs) in enumerate(zip(data_partitions, drs_partitions)):
         df = pd.DataFrame({'data_path': data, 'drs_path': drs})
         df=df.copy()
         df["bunch_index"] = num
-        
+
+        df_runs = df_runs.append(df)
+
         if output_path:
             # create the filenames for each single local run
             file_name, _ = path.splitext(path.basename(output_path))
@@ -55,7 +58,7 @@ def make_jobs(jar, xml, data_paths, drs_paths,
 
     avg_num_files = np.mean([len(part) for part in data_partitions])
     logger.info("Created {} jobs with {} files each.".format(len(jobs), avg_num_files))
-    return jobs
+    return jobs, df_runs
 
 
 
@@ -135,20 +138,18 @@ def main( jar, xml, out, mc_path, queue, walltime, engine, num_jobs, vmem, log_l
     drs_paths_array = np.repeat(np.array(drspath), len(mc_paths_array))
 
     if local_output:
-        job_list = make_jobs(
-                        jarpath, xmlpath, mc_paths_array,
-                        drs_paths_array,  engine, queue,
-                        vmem, num_jobs, walltime, output_path=local_output_dir, local_output_extension=local_output_extension
-                        )
+        output_path=local_output_dir
     else:
-        job_list = make_jobs(
-                        jarpath, xmlpath, mc_paths_array,
-                        drs_paths_array,  engine, queue,
-                        vmem, num_jobs, walltime
-                        )
+        output_path=None
+        
+    job_list, df_runs = make_jobs(
+                    jarpath, xmlpath, mc_paths_array,
+                    drs_paths_array,  engine, queue,
+                    vmem, num_jobs, walltime, output_path=output_path, local_output_extension=local_output_extension
+                    )
 
     job_outputs = gridmap.process_jobs(job_list, max_processes=num_jobs, local=local)
-    erna.collect_output(job_outputs, out)
+    erna.collect_output(job_outputs, out, df_runs)
 
 if __name__ == "__main__":
     main()

--- a/erna/scripts/process_fact_run_list.py
+++ b/erna/scripts/process_fact_run_list.py
@@ -99,8 +99,19 @@ def main(file_list, jar, xml, aux_source, out, queue, walltime, engine, num_jobs
     logging.captureWarnings(True)
     logging.basicConfig(format=('%(asctime)s - %(name)s - %(levelname)s - ' +  '%(message)s'), level=level)
 
-    df = pd.read_json(file_list)
-    logger.info("Read {} runs from .json file".format(len(df)))
+    name, extension = os.path.splitext(file_list)
+
+    if extension not in ['.json', '.csv']:
+        logger.error("Did not recognize file extension {}.".format(extension))
+        exit(0)
+    elif extension == '.json':
+        logger.info("Reading JSON from {}".format(file_list))
+        df = pd.read_json(file_list)
+    elif extension == '.csv':
+        logger.info("Reading CSV from {}".format(file_list))
+        df_returned_data.read_csv(file_list)
+
+    logger.info("Read {} runs".format(len(df)))
 
     #get data files
     jarpath = path.abspath(jar)


### PR DESCRIPTION
* in order to reprocess failed runs also allow csv and json as input file list. 
* don't write freatures to failed file list. (Prevent overhead)
* adds the handling of submit MC runs 
* `process_fact_mc` and `process_fact_data` write a CSV of failed runs if they failed